### PR TITLE
Vec.fill() is deprecated

### DIFF
--- a/3.2_collections.ipynb
+++ b/3.2_collections.ipynb
@@ -545,8 +545,7 @@
     "    })\n",
     "    \n",
     "    // A Register of a vector of UInts\n",
-    "    // fromBits(0.U) is a bit of a hack to have reg reset to zero\n",
-    "    val reg = RegInit( Vec(32, UInt(32.W)).fromBits(0.U) )\n",
+    "    val reg = RegInit(VecInit(Seq.fill(32)(0.U(32.W))))\n",
     "\n",
     "}"
    ]

--- a/3.2_collections.ipynb
+++ b/3.2_collections.ipynb
@@ -459,7 +459,7 @@
     "  })\n",
     "\n",
     "  // Reference solution\n",
-    "  val regs = RegInit(Vec.fill(length - 1)(0.U(8.W)))\n",
+    "  val regs = RegInit(VecInit(Seq.fill(length - 1)(0.U(8.W))))\n",
     "  for(i <- 0 until length - 1) {\n",
     "      if(i == 0) regs(i) := io.in\n",
     "      else       regs(i) := regs(i - 1)\n",


### PR DESCRIPTION
As message say when it's executed : Vec.fill() is deprecated we have to use VecInit(Seq.fill()) now.