### PR TITLE
3.6_types: avoid deprecation warning with cloneType

### DIFF
--- a/3.6_types.ipynb
+++ b/3.6_types.ipynb
@@ -684,6 +684,7 @@
     "    \n",
     "    val in = Input(gen.cloneType)\n",
     "    val out = Output(Vec(n + 1, gen.cloneType)) // + 1 because in is included in out\n",
+    "    override def cloneType: this.type = (new ShiftRegisterIO(gen, n)).asInstanceOf[this.type]\n",
     "}\n",
     "\n",
     "class ShiftRegister[T <: Data](gen: T, n: Int) extends Module {\n",


### PR DESCRIPTION
There is a deprecation warning if we do not overwrite cloneType in ShiftRegisterIO declaration : 
```
[info] [0.000] Elaborating design...
[deprecated] class ammonite.$sess.cmd22$Helper$ShiftRegisterIO (1 calls): Unable to automatically infer cloneType on class ammonite.$sess.cmd22$Helper$ShiftRegisterIO: constructor has parameters (gen, n) that are not both immutable and accessible. Either make all parameters immutable and accessible (vals) so cloneType can be inferred, or define a custom cloneType method.
[warn] There were 1 deprecated function(s) used. These may stop compiling in a future release, you are encouraged to fix these issues.
[warn] Line numbers for deprecations reported by Chisel may be inaccurate, enable scalac compiler deprecation warnings by either:
[warn]   In the sbt interactive console, enter:
[warn]     set scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
[warn]   or, in your build.sbt, add the line:
[warn]     scalacOptions := Seq("-unchecked", "-deprecation")
[info] [0.130] Done elaborating.
Total FIRRTL Compile Time: 26.3 ms
Total FIRRTL Compile Time: 18.4 ms
End of dependency graph
Circuit state created
```
This commit add overwrite line in Bundle to avoid it.