### PR TITLE
Use 3.2.0 release.

### DIFF
--- a/source/load-ivy.sc
+++ b/source/load-ivy.sc
@@ -10,12 +10,12 @@ interp.configureCompiler(x => x.settings.source.value = scala.tools.nsc.settings
 // System.setProperty("https.proxyHost", "proxy.example.com")
 // System.setProperty("https.proxyPort", "3128")
 
-import $ivy.`edu.berkeley.cs::chisel3:3.2-SNAPSHOT` 
-import $ivy.`edu.berkeley.cs::chisel-iotesters:1.3-SNAPSHOT`
-import $ivy.`edu.berkeley.cs::chisel-testers2:0.1-SNAPSHOT`
+import $ivy.`edu.berkeley.cs::chisel3:3.2.0` 
+import $ivy.`edu.berkeley.cs::chisel-iotesters:1.3.0`
+import $ivy.`edu.berkeley.cs::chisel-testers2:0.1.0`
 import $ivy.`edu.berkeley.cs::dsptools:1.1.0`
 import $ivy.`org.scalanlp::breeze:0.13.2`
-import $ivy.`edu.berkeley.cs::rocket-dsptools:1.2-020719-SNAPSHOT`
+import $ivy.`edu.berkeley.cs::rocket-dsptools:1.2.0`
 
 // Convenience function to invoke Chisel and grab emitted Verilog.
 def getVerilog(dut: => chisel3.core.UserModule): String = {

--- a/source/load-ivy.sc
+++ b/source/load-ivy.sc
@@ -13,7 +13,7 @@ interp.configureCompiler(x => x.settings.source.value = scala.tools.nsc.settings
 import $ivy.`edu.berkeley.cs::chisel3:3.2.0` 
 import $ivy.`edu.berkeley.cs::chisel-iotesters:1.3.0`
 import $ivy.`edu.berkeley.cs::chisel-testers2:0.1.0`
-import $ivy.`edu.berkeley.cs::dsptools:1.1.0`
+import $ivy.`edu.berkeley.cs::dsptools:1.2.0`
 import $ivy.`org.scalanlp::breeze:0.13.2`
 import $ivy.`edu.berkeley.cs::rocket-dsptools:1.2.0`
 


### PR DESCRIPTION
Update to "release" versions of chisel ecosystem. **NOTE**: chisel-testers2 v0.1.0 is in the process of being published for this. I won't merge this PR until that publishing is complete. Once this PR has been merged, can someone push the update to binder hub, or leave instructions on how to do so?
