### PR TITLE
updates to load-ivy for coursier changes

### DIFF
--- a/source/load-ivy.sc
+++ b/source/load-ivy.sc
@@ -1,5 +1,5 @@
-interp.repositories() ++= Seq( 
-  coursier.maven.MavenRepository("https://oss.sonatype.org/content/repositories/snapshots")
+interp.repositories() ::: List(
+  coursierapi.MavenRepository.of("https://oss.sonatype.org/content/repositories/snapshots")
 )
 
 @


### PR DESCRIPTION
Following the instructions for a local setup I ran into a few issues using `almond==0.9.0` that seem to be related to some changes in `coursier`. I'm not really sure what I'm doing but following [this issue](https://github.com/lihaoyi/Ammonite/issues/1003) I was able to get things working with the following changes. 

* ++= Seq -> ::: List
* MavenRepository moved from coursier.maven -> coursierapi
* MavenRepository.of("http:...")