### PR TITLE
Fix an error due to update of coursierapi

### DIFF
--- a/source/load-ivy.sc
+++ b/source/load-ivy.sc
@@ -1,5 +1,11 @@
-interp.repositories() ++= Seq( 
-  coursier.maven.MavenRepository("https://oss.sonatype.org/content/repositories/snapshots")
+// interp.repositories() ++= Seq( 
+//   coursier.maven.MavenRepository("https://oss.sonatype.org/content/repositories/snapshots")
+// )
+
+import coursierapi.MavenRepository
+
+interp.repositories.update(
+  interp.repositories() ::: List(MavenRepository.of("https://oss.sonatype.org/content/repositories/snapshots"))
 )
 
 @


### PR DESCRIPTION
Running the first block of 2.1 to download chisel would cause the error of:
'Main.sc:1: value ++= is not a member of List[coursierapi.Repository]'

This is due to the update of coursierapi. I changed the file source/load-ivy.sc and the error is resolved.