### PR TITLE
2.3_control_flow.ipynb: remove a duplicated "must"

### DIFF
--- a/2.3_control_flow.ipynb
+++ b/2.3_control_flow.ipynb
@@ -115,7 +115,7 @@
     "  // things to do if none of th boolean conditions are true\n",
     "}\n",
     "```\n",
-    "They must must appear in the above order, though either of the latter may be omitted.\n",
+    "They must appear in the above order, though either of the latter may be omitted.\n",
     "There can be as many elsewhen clauses as desired.\n",
     "Any section that is true terminates the construct.\n",
     "Actions taken in the bodies of the the three can be complex blocks and may contain nested\n",


### PR DESCRIPTION
In section 2.3, chapter "when, elsewhen, and otherwise" there is a sentence with "must must". This PR removes one "must" so that the grammar looks correct. :smiley: