### PR TITLE
Bump ALMOND_VERSION

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCALA_VERSION=2.12.8 ALMOND_VERSION=0.2.1
+SCALA_VERSION=2.12.8 ALMOND_VERSION=0.9.1
 
 # Install coursier
 curl -Lo coursier https://git.io/coursier-cli


### PR DESCRIPTION
We're seeing a crash in attempting to install almond:
```
Step 48/51 : RUN ./binder/postBuild
 ---> Running in e82af2310378
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   135  100   135    0     0    263      0 --:--:-- --:--:-- --:--:--   263
100 27428  100 27428    0     0  38849      0 --:--:-- --:--:-- --:--:-- 38849
Downloaded 1 missing file(s) / 56
Downloaded 2 missing file(s) / 56
 ...
Downloaded https://jitpack.io/com/github/jupyter/jvm-repr/0.3.1/jvm-repr-0.3.1-sources.jar.sha1
Downloaded https://jitpack.io/com/github/jupyter/jvm-repr/0.3.1/jvm-repr-0.3.1.jar.sha1
Exception in thread "main" java.lang.RuntimeException: should not happen
        at scala.sys.package$.error(package.scala:30)
        at coursier.cli.bootstrap.Bootstrap$.$anonfun$run$23(Bootstrap.scala:342)
        at scala.collection.MapLike.getOrElse(MapLike.scala:131)
        at scala.collection.MapLike.getOrElse$(MapLike.scala:129)
        at scala.collection.AbstractMap.getOrElse(Map.scala:63)
        at coursier.cli.bootstrap.Bootstrap$.$anonfun$run$22(Bootstrap.scala:342)
        at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
        at scala.collection.Iterator.foreach(Iterator.scala:941)
        at scala.collection.Iterator.foreach$(Iterator.scala:941)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
        at scala.collection.IterableLike.foreach(IterableLike.scala:74)
        at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
        at scala.collection.TraversableLike.map(TraversableLike.scala:238)
        at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
        at scala.collection.AbstractTraversable.map(Traversable.scala:108)
        at coursier.cli.bootstrap.Bootstrap$.$anonfun$run$21(Bootstrap.scala:342)
        at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
        at scala.collection.immutable.List.foreach(List.scala:392)
        at scala.collection.TraversableLike.map(TraversableLike.scala:238)
        at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
        at scala.collection.immutable.List.map(List.scala:298)
        at coursier.cli.bootstrap.Bootstrap$.run(Bootstrap.scala:340)
        at coursier.cli.Coursier$.$anonfun$runA$2(Coursier.scala:98)
        at coursier.cli.Coursier$.$anonfun$runA$2$adapted(Coursier.scala:96)
        at coursier.cli.CommandAppPreA.run(CommandAppPreA.scala:22)
        at caseapp.core.app.CommandAppWithPreCommand.$anonfun$main$5(CommandAppWithPreCommand.scala:99)
        at caseapp.core.app.CommandAppWithPreCommand.$anonfun$main$5$adapted(CommandAppWithPreCommand.scala:99)
        at scala.util.Either.fold(Either.scala:191)
        at caseapp.core.app.CommandAppWithPreCommand.$anonfun$main$3(CommandAppWithPreCommand.scala:99)
        at caseapp.core.app.CommandAppWithPreCommand.$anonfun$main$3$adapted(CommandAppWithPreCommand.scala:85)
        at scala.Option.foreach(Option.scala:407)
        at caseapp.core.app.CommandAppWithPreCommand.main(CommandAppWithPreCommand.scala:85)
        at coursier.cli.Coursier$.main(Coursier.scala:71)
        at coursier.cli.Coursier.main(Coursier.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at coursier.bootstrap.launcher.a.a(Unknown Source)
        at coursier.bootstrap.launcher.Launcher.main(Unknown Source)
./binder/postBuild: line 16: ./almond: No such file or directory
Building jupyterlab assets (build:prod:minimize)
|
Setting up libdbus-1-3:amd64 (1.12.2-1ubuntu1.1) ...
```