### PR TITLE
fix(load-ivy.sc): remove redundant space created by `generateVisualizations`

### DIFF
--- a/source/load-ivy.sc
+++ b/source/load-ivy.sc
@@ -160,10 +160,10 @@ def generateVisualizations(gen: () => chisel3.RawModule): (String, String) = {
     s"cp build/${readableTop}_hierarchy.dot.svg build/${uniqueTop}_hierarchy.dot.svg"!!
     
     val moduleView = targetDir + "/" + uniqueTop + ".dot.svg"
-    val x = """<a name="top"></a><img src=" """ + moduleView + """" alt="Module View";" />"""
+    val x = """<a name="top"></a><img src="""" + moduleView + """" alt="Module View";" />"""
     
     val instanceView = targetDir + "/" + uniqueTop + "_hierarchy.dot.svg"
-    val y = """<a name="top"></a><img src=" """ + instanceView + """" alt="Hierarchy View" style="width:480px;" />"""
+    val y = """<a name="top"></a><img src="""" + instanceView + """" alt="Hierarchy View" style="width:480px;" />"""
     (x, y)
 
 }


### PR DESCRIPTION
The following code create extra leading space in string.

https://github.com/freechipsproject/chisel-bootcamp/blob/ff68b6671e3c63c7d23d98a03b5bc1ad38eb733c/source/load-ivy.sc#L163
https://github.com/freechipsproject/chisel-bootcamp/blob/ff68b6671e3c63c7d23d98a03b5bc1ad38eb733c/source/load-ivy.sc#L166

Jupyterlab currently will wrongly encode the leading and trailing space to `%20`, so the image won't display as expected.

So, maybe just remove the space will help. 