### PR TITLE
Local installation using Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/Dockerfile
+/diagrams/*
+/.ipynb_checkpoints/

--- a/.github/workflows/build-push-docker-image.yaml
+++ b/.github/workflows/build-push-docker-image.yaml
@@ -1,0 +1,20 @@
+name: Publish Docker image
+on:
+  push:
+    branches: [ master ]
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          repository: sterin/chisel-bootcamp
+          tag_with_ref: true

--- a/.github/workflows/build-push-docker-image.yaml
+++ b/.github/workflows/build-push-docker-image.yaml
@@ -16,5 +16,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          repository: sterin/chisel-bootcamp
+          repository: ucb-bar/chisel-bootcamp
           tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,8 @@ ADD . /home/bootcamp/
 RUN mkdir -p ~/.jupyter/custom
 RUN cp source/custom.js ~/.jupyter/custom/custom.js
 
+# Execute a notebook to ensure Chisel is downloaded into the image for offline work
+RUN jupyter nbconvert --to html --output=/tmp/ --execute 0_demo.ipynb
+
 EXPOSE 8888
 ENTRYPOINT jupyter notebook --no-browser --ip 0.0.0.0 --port 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,7 @@ RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         ca-certificates-java \
         curl \
-        git \
         graphviz \
-        openjdk-8-jdk-headless \
         openjdk-8-jre-headless \
         python3-pip \
         && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN \
     ./almond --install && \
     rm -f coursier almond
 
-ADD . /home/bootcamp/
+ADD --chown=bootcamp:bootcamp . /chisel-bootcamp/
+WORKDIR /chisel-bootcamp
 
 RUN mkdir -p ~/.jupyter/custom
 RUN cp source/custom.js ~/.jupyter/custom/custom.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ RUN \
         curl \
         graphviz \
         openjdk-8-jre-headless \
-        python3-pip \
+        python3-distutils \
         && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip
-RUN pip3 install jupyter
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3 get-pip.py
+RUN pip3 install notebook
 
 RUN useradd -ms /bin/bash bootcamp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+# First stage : setup the system and environment
+FROM ubuntu:20.04 as base
 
 RUN \
     apt-get update && \
@@ -17,11 +18,24 @@ RUN pip3 install notebook
 
 RUN useradd -ms /bin/bash bootcamp
 
-USER bootcamp
-WORKDIR /home/bootcamp
-
 ENV SCALA_VERSION=2.12.10
 ENV ALMOND_VERSION=0.9.1
+
+ENV COURSIER_CACHE=/coursier_cache
+
+ADD . /chisel-bootcamp/
+WORKDIR /chisel-bootcamp
+
+ENV JUPYTER_CONFIG_DIR=/jupyter/config
+ENV JUPITER_DATA_DIR=/jupyter/data
+
+RUN mkdir -p $JUPYTER_CONFIG_DIR/custom
+RUN cp source/custom.js $JUPYTER_CONFIG_DIR/custom/
+
+# Second stage - download Scala requirements and the Scala kernel
+FROM base as intermediate-builder
+
+RUN mkdir /coursier_cache
 
 RUN \
     curl -L -o coursier https://git.io/coursier-cli && \
@@ -29,23 +43,27 @@ RUN \
     ./coursier \
         bootstrap \
         -r jitpack \
-        -i user \
-        -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
         sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
         --sources \
         --default=true \
         -o almond && \
-    ./almond --install && \
-    rm -f coursier almond
-
-ADD --chown=bootcamp:bootcamp . /chisel-bootcamp/
-WORKDIR /chisel-bootcamp
-
-RUN mkdir -p ~/.jupyter/custom
-RUN cp source/custom.js ~/.jupyter/custom/custom.js
+    ./almond --install --global && \
+    \rm -rf almond couriser /root/.cache/coursier 
 
 # Execute a notebook to ensure Chisel is downloaded into the image for offline work
-RUN jupyter nbconvert --to html --output=/tmp/ --execute 0_demo.ipynb
+RUN jupyter nbconvert --to notebook --output=/tmp/0_demo --execute 0_demo.ipynb
+
+# Last stage
+FROM base as final
+
+# copy the Scala requirements and kernel into the image 
+COPY --from=intermediate-builder /coursier_cache/ /coursier_cache/
+COPY --from=intermediate-builder /usr/local/share/jupyter/kernels/scala/ /usr/local/share/jupyter/kernels/scala/
+
+RUN chown -R bootcamp:bootcamp /chisel-bootcamp
+
+USER bootcamp
+WORKDIR /chisel-bootcamp
 
 EXPOSE 8888
-ENTRYPOINT jupyter notebook --no-browser --ip 0.0.0.0 --port 8888
+CMD jupyter notebook --no-browser --ip 0.0.0.0 --port 8888

--- a/Install.md
+++ b/Install.md
@@ -17,7 +17,7 @@ Make sure you have Docker [installed](https://docs.docker.com/get-docker/) on yo
 Run the following command:
 
 ```
-docker run -it --rm -p 8888:8888 sterin/chisel-bootcamp
+docker run -it --rm -p 8888:8888 ucb-bar/chisel-bootcamp
 ```
 
 This will download a Dokcer image for the bootcamp and run it. The output will end in the following message:

--- a/Install.md
+++ b/Install.md
@@ -10,6 +10,28 @@ If you do have multiple version of Java, make sure to select Java 8 (1.8) before
 * On Windows: https://gist.github.com/rwunsch/d157d5fe09e9f7cdc858cec58c8462d6
 * On Mac OS: https://stackoverflow.com/questions/21964709/how-to-set-or-change-the-default-java-jdk-version-on-os-x
 
+### Local Installation using Docker - Linux/Mac/Windows
+
+Make sure you have Docker [installed](https://docs.docker.com/get-docker/) on your system.
+
+Run the following command:
+
+```
+docker run -it --rm -p 8888:8888 sterin/chisel-bootcamp
+```
+
+This will download a Dokcer image for the bootcamp and run it. The output will end in the following message:
+
+```
+    To access the notebook, open this file in a browser:
+        file:///home/bootcamp/.local/share/jupyter/runtime/nbserver-6-open.html
+    Or copy and paste one of these URLs:
+        http://79b8df8411f2:8888/?token=LONG_RANDOM_TOKEN
+     or http://127.0.0.1:8888/?token=LONG_RANDOM_TOKEN
+```
+
+Copy the last link, the one starting with https://127.0.0.1:8888 to your browser and follow the Bootcamp.
+
 ### Local Installation - Mac/Linux
 
 This bootcamp uses Jupyter notebooks.


### PR DESCRIPTION
Hi,

On machines with Docker installed, it is much easier to run a docker image than to follow the instructions to locally install the bootcamp.

I've prepared a Dockerfile and A GitHub action that builds the docker image and pushes it to Docker Hub on each update to the GitHub repository.

If this is of interest, It would probably be better to push the image to your own account on Docker Hub. The required changes are:

1. Create a new Docker Hub account
2. Create an access token at  https://hub.docker.com/settings/security 
3. Add new secrets at the GitHub repository names `DOCKER_HUB_USERNAME` and `DOCKER_HUB_ACCESS_TOKEN`
4. Change the name of the repository from `sterin/chisel-bootcamp` to the new `username/chisel-bootcamp` in both install.md and .github/workflows/build-push-docker-iamge.yaml

