### PR TITLE
build(dockerfile): Change coursier_cache owner to bootcamp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ FROM base as final
 COPY --from=intermediate-builder /coursier_cache/ /coursier_cache/
 COPY --from=intermediate-builder /usr/local/share/jupyter/kernels/scala/ /usr/local/share/jupyter/kernels/scala/
 
-RUN chown -R bootcamp:bootcamp /chisel-bootcamp
+RUN chown -R bootcamp:bootcamp /chisel-bootcamp /coursier_cache
 
 USER bootcamp
 WORKDIR /chisel-bootcamp


### PR DESCRIPTION
Add `chown -R bootcamp:bootcamp /coursier_cach` to fix problem mentioned in #140 

I have tested in my repo.