### PR TITLE
 honor the 'ready' signal from the GCD output (v2)

### DIFF
--- a/2.6_chiseltest.ipynb
+++ b/2.6_chiseltest.ipynb
@@ -214,7 +214,7 @@
     "  val in = IO(Flipped(Decoupled(ioType)))\n",
     "  val out = IO(Decoupled(ioType))\n",
     "  out <> Queue(in, entries)\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -339,7 +339,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "test(QueueModule(UInt(9.W), entries = 200)) { c =>\n",
     "    // Example testsequence showing the use and behavior of Queue\n",
     "    c.in.initSource()\n",
@@ -434,12 +433,13 @@
     "      y := y - x\n",
     "    }\n",
     "    when(y === 0.U) {\n",
-    "      // when y becomes zero computation is over, signal valid data to output\n",
+    "      // when y becomes zero computation is over,\n",
+    "      // signal valid data to output if the output is ready\n",
     "      output.bits.value1 := xInitial\n",
     "      output.bits.value2 := yInitial\n",
     "      output.bits.gcd := x\n",
     "      output.valid := true.B\n",
-    "      busy := false.B\n",
+    "      busy := ! output.ready\n",
     "    }\n",
     "  }.otherwise {\n",
     "    when(input.valid) {\n",
@@ -453,7 +453,7 @@
     "      resultValid := false.B\n",
     "    }\n",
     "  }\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -498,7 +498,10 @@
     "  fork {\n",
     "    dut.input.enqueueSeq(inputSeq)\n",
     "  }.fork {\n",
-    "    dut.output.expectDequeueSeq(resultSeq)\n",
+    "    for (expected <- resultSeq) {\n",
+    "      dut.output.expectDequeue(expected)\n",
+    "      dut.clock.step(5) // wait some cycles before receiving the next output to create backpressure\n",
+    "    }\n",
     "  }.join()\n",
     "}\n"
    ]


### PR DESCRIPTION
2nd attempt at #134 
but it doesn't address the data validity concerns expressed there. I think it's why I removed the register in my previous PR https://github.com/freechipsproject/chisel-bootcamp/pull/153/files#diff-d0cf6f075ca780e47d3802aa0752cdb5f172ad6783391a517515039b8124cbe4L423
and I should probably do that here too, right?