### PR TITLE
Use Jupyter Lab instead of Jupyter Notebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3 get-pip.py
-RUN pip3 install notebook
+RUN pip3 install jupyterlab
 
 RUN useradd -ms /bin/bash bootcamp
 
@@ -66,4 +66,5 @@ USER bootcamp
 WORKDIR /chisel-bootcamp
 
 EXPOSE 8888
-CMD jupyter notebook --no-browser --ip 0.0.0.0 --port 8888
+CMD jupyter lab --no-browser --ip 0.0.0.0 --port 8888
+


### PR DESCRIPTION
Updated the dockerfile in order to use JupyterLab, as the Binder does.