### PR TITLE
Module 2.6 - Removed usage of case class to maintain consistency

### DIFF
--- a/2.6_chiseltest.ipynb
+++ b/2.6_chiseltest.ipynb
@@ -210,19 +210,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "case class QueueModule[T <: Data](ioType: T, entries: Int) extends MultiIOModule {\n",
+    "class QueueModule[T <: Data](ioType: T, entries: Int) extends MultiIOModule {\n",
     "  val in = IO(Flipped(Decoupled(ioType)))\n",
     "  val out = IO(Decoupled(ioType))\n",
     "  out <> Queue(in, entries)\n",
     "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> Note the `case` class modifer is not generally required but seems to be in order for\n",
-    "this example to be re-used in multiple cells in Jupyter"
    ]
   },
   {
@@ -249,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test(QueueModule(UInt(9.W), entries = 200)) { c =>\n",
+    "test(new QueueModule(UInt(9.W), entries = 200)) { c =>\n",
     "    // Example testsequence showing the use and behavior of Queue\n",
     "    c.in.initSource()\n",
     "    c.in.setSourceClock(c.clock)\n",
@@ -286,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test(QueueModule(UInt(9.W), entries = 200)) { c =>\n",
+    "test(new QueueModule(UInt(9.W), entries = 200)) { c =>\n",
     "    // Example testsequence showing the use and behavior of Queue\n",
     "    c.in.initSource()\n",
     "    c.in.setSourceClock(c.clock)\n",
@@ -339,7 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test(QueueModule(UInt(9.W), entries = 200)) { c =>\n",
+    "test(new QueueModule(UInt(9.W), entries = 200)) { c =>\n",
     "    // Example testsequence showing the use and behavior of Queue\n",
     "    c.in.initSource()\n",
     "    c.in.setSourceClock(c.clock)\n",


### PR DESCRIPTION
### Why is this change being made?
To maintain consistency throughout the modules of the chisel bootcamp and to rectify the cause of inexplicable behavior that can potentially undermine Chisel and its support.

### What was changed?
Removed the usage of case class modifier when declaring the QueueModule. Modified the instance creation of QueueModule to work with non-case class QueueModule. 

### How this was tested or validated
Tested the functionality of the modified code by making changes on Binder and on local Jupyter Notebook.
