### PR TITLE
Module name error removed

### DIFF
--- a/2.1_first_module.ipynb
+++ b/2.1_first_module.ipynb
@@ -139,8 +139,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the Name of our module is `cmd<#>WrapperHelperPassthrough`, which is an artifact of running this tutorial in Jupyter. In your normal code, its name should just be `Passthrough`. This is an important lesson though - although Chisel does its best to preserve the names of your modules and other hardware components, sometimes it fails to do so.\n",
-    "\n",
     "<span style=\"color:blue\">**Example: A Module Generator**</span><br>\n",
     "If we apply what we learned about Scala to this example, we can see that a Chisel module is implemented as a Scala class. Just like any other Scala class, we could make a Chisel module take some construction parameters. In this case, we make a new class `PassthroughGenerator` which will accept an integer `width` that dictates the widths of its input and output ports:"
    ]


### PR DESCRIPTION
The module name is consistent as of v3.4.0 which makes the warning unnecessary.