### PR TITLE
Docker: universal (arm64/amd64) builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,3 +30,4 @@ jobs:
         with:
           tags: ucbbar/chisel-bootcamp:latest
           push: ${{ github.event_name == 'push' }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
# Intro

I added the platforms tag to create both ARM and x86 builds. This lets us use the bootcamp on devices such as the M series Macs.

While I'm aware there's a mybinder link that lets you run the bootcamp in the browser, it often goes offline and you lose your process.

# Testing that was done

1. Tested the new workflow with Act (https://github.com/nektos/act, a tool to locally run GitHub workflows), it still builds
2. [Pushed the Docker image under my own repo](https://hub.docker.com/repository/docker/peterwilli/chisel_bootcamp/general) and ran it on my m2 Macbook Air, I can run the bootcamp in the notebooks!

It should be a drop-in replacement with no further action required